### PR TITLE
Added support for capitalized letters in domain name.

### DIFF
--- a/pydnsbl/checker.py
+++ b/pydnsbl/checker.py
@@ -172,6 +172,7 @@ class DNSBLDomainChecker(BaseDNSBLChecker):
                  tries=tries, concurrency=concurrency, loop=loop)
 
     def prepare_query(self, request):
+        request = request.lower() # Adding support for capitalized letters in domain name.
         domain_idna = idna.encode(request).decode()
         if not self.DOMAIN_REGEX.match(domain_idna):
             raise ValueError('should be valid domain, got %s' % domain_idna)

--- a/pydnsbl/tests.py
+++ b/pydnsbl/tests.py
@@ -64,6 +64,16 @@ def test_wrong_domain_format():
         with pytest.raises(ValueError):
              print(checker.check(ip))
 
+def test_capitalization_in_domain():
+    capitalized_domains = ['Google.com', 'Facebook.com']
+    for domain in capitalized_domains:
+        checker = DNSBLDomainChecker()
+        res = checker.check(domain)
+        assert not res.blacklisted
+        assert not res.categories
+        assert not res.detected_by
+        assert not res.failed_providers
+
 
 ## COMPAT TESTS
 def test_checker_compat_0_6():


### PR DESCRIPTION
Hi, 

I was creating an application with flask and pydnsbl to check for blacklisted domains. One guy from our business team, used an iPad to access the application and when he put the domain, Apple keyboard *auto magically* capitalized the first letter and all hell broke loose. I fixed it in my application level but thought to add this support to your repo.  