### PR TITLE
Remove dnsbl.inps.de

### DIFF
--- a/pydnsbl/checker.py
+++ b/pydnsbl/checker.py
@@ -191,5 +191,5 @@ class DNSBLChecker(DNSBLIpChecker):
         return self.check(addr)
 
     def check_ips(self, addrs):
-        warnings.warn('deprecated, use bullk check method instead', DeprecationWarning)
+        warnings.warn('deprecated, use bulk check method instead', DeprecationWarning)
         return self.bulk_check(addrs)

--- a/pydnsbl/providers.py
+++ b/pydnsbl/providers.py
@@ -79,7 +79,6 @@ _BASE_PROVIDERS = [
     'dnsbl-2.uceprotect.net',
     'dnsbl-3.uceprotect.net',
     'dnsbl.cyberlogic.net',
-    'dnsbl.inps.de',
     'dnsbl.sorbs.net',
     'drone.abuse.ch',
     'dul.dnsbl.sorbs.net',


### PR DESCRIPTION
The service was permanently shut down on 2020-05-25. See: http://inps.de/