### PR TITLE
Specify nameservers directly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- nameserver specification support for DNSBLIpChecker
+
+
 ## [1.1.0] - 2020-09-27
 ### Added
 - ipv6 support for DNSBLIpChecker

--- a/pydnsbl/checker.py
+++ b/pydnsbl/checker.py
@@ -72,11 +72,12 @@ class DNSBLResponse:
     """
     DNSBL Response object
     """
-    def __init__(self, addr=None, provider=None, response=None, error=None):
+    def __init__(self, addr=None, provider=None, response=None, error=None, ns=None):
         self.addr = addr
         self.provider = provider
         self.response = response
         self.error = error
+        self.ns = ns
 
 class BaseDNSBLChecker(abc.ABC):
     """ BASE Checker for DNSBL lists
@@ -84,6 +85,7 @@ class BaseDNSBLChecker(abc.ABC):
             * providers(list) - list of providers (Provider instance or str)
             * timeout(int) - timeout of dns requests will be passed to resolver
             * tries(int) - retry times
+            * ns(list) - nameservers to use for lookup
     """
 
     def __init__(self, providers=BASE_PROVIDERS, timeout=5,
@@ -101,7 +103,7 @@ class BaseDNSBLChecker(abc.ABC):
                 asyncio.set_event_loop(self._loop)
         else:
             self._loop = loop
-        self._resolver = aiodns.DNSResolver(timeout=timeout, tries=tries, loop=self._loop)
+        self._resolver = aiodns.DNSResolver(timeout=timeout, tries=tries, loop=self._loop, nameservers=ns)
         self._semaphore = asyncio.Semaphore(concurrency)
 
 

--- a/pydnsbl/checker.py
+++ b/pydnsbl/checker.py
@@ -72,12 +72,11 @@ class DNSBLResponse:
     """
     DNSBL Response object
     """
-    def __init__(self, addr=None, provider=None, response=None, error=None, ns=None):
+    def __init__(self, addr=None, provider=None, response=None, error=None):
         self.addr = addr
         self.provider = provider
         self.response = response
         self.error = error
-        self.ns = ns
 
 class BaseDNSBLChecker(abc.ABC):
     """ BASE Checker for DNSBL lists
@@ -89,8 +88,9 @@ class BaseDNSBLChecker(abc.ABC):
     """
 
     def __init__(self, providers=BASE_PROVIDERS, timeout=5,
-                 tries=2, concurrency=200, loop=None):
+                 tries=2, concurrency=200, loop=None, ns=None):
         self.providers = []
+        self.ns = ns
         for provider in providers:
             if not isinstance(provider, Provider):
                 raise ValueError('providers should contain only Provider instances')

--- a/pydnsbl/providers.py
+++ b/pydnsbl/providers.py
@@ -15,8 +15,13 @@ DNSBL_CATEGORY_LEGIT = 'legit'
 
 class Provider(object):
 
-    def __init__(self, host):
+    def __init__(self, host, ns=None):
+        """
+        host: the hostname of provider
+        ns: the nameserver IP to use for direct lookup
+        """
         self.host = host
+        self.ns = ns
 
     def process_response(self, response):
         """
@@ -138,8 +143,8 @@ class DblSpamhaus(Provider):
         '127.0.1.106': {DNSBL_CATEGORY_ABUSED,  DNSBL_CATEGORY_LEGIT, DNSBL_CATEGORY_CNC}
     }
 
-    def __init__(self, host='dbl.spamhaus.org'):
-        Provider.__init__(self, host=host)
+    def __init__(self, host='dbl.spamhaus.org', ns=None):
+        Provider.__init__(self, host=host, ns=ns)
 
     def process_response(self, response):
         categories = set()

--- a/pydnsbl/providers.py
+++ b/pydnsbl/providers.py
@@ -2,6 +2,8 @@
 Place to define providers.
 Most part of _BASE_PROVIDERS was taken from https://github.com/vincecarney/dnsbl
 """
+import os
+
 ### DNSBL CATEGORIES ###
 # providers answers could be interpreted in one of the following categories
 DNSBL_CATEGORY_UNKNOWN = 'unknown'
@@ -164,5 +166,9 @@ _DOMAIN_PROVIDERS = [
     'rhsbl.sorbs.net '
 ]
 
-BASE_PROVIDERS = [Provider(host) for host in _BASE_PROVIDERS] + [ZenSpamhaus()]
-BASE_DOMAIN_PROVIDERS = [Provider(host) for host in _DOMAIN_PROVIDERS] + [DblSpamhaus()]
+BASE_PROVIDERS = [Provider(host) for host in _BASE_PROVIDERS]
+BASE_DOMAIN_PROVIDERS = [Provider(host) for host in _DOMAIN_PROVIDERS]
+
+if os.getenv('USE_SPAMHAUS', 'false') == 'true':
+    BASE_PROVIDERS.append(ZenSpamhaus())
+    BASE_DOMAIN_PROVIDERS.append(DblSpamhaus())

--- a/pydnsbl/providers.py
+++ b/pydnsbl/providers.py
@@ -12,6 +12,7 @@ DNSBL_CATEGORY_MALWARE = 'malware'
 DNSBL_CATEGORY_CNC = 'cnc'
 DNSBL_CATEGORY_ABUSED = 'abused'
 DNSBL_CATEGORY_LEGIT = 'legit'
+DNSBL_CATEGORY_DYNAMIC = 'dynamic'
 
 class Provider(object):
 
@@ -62,6 +63,8 @@ class ZenSpamhaus(Provider):
                 categories.add(DNSBL_CATEGORY_SPAM)
             elif result.host in ['127.0.0.4', '127.0.0.5', '127.0.0.6', '127.0.0.7']:
                 categories.add(DNSBL_CATEGORY_EXPLOITS)
+            elif result.host in ['127.0.0.10', '127.0.0.11']:
+                categories.add(DNSBL_CATEGORY_DYNAMIC)
             else:
                 categories.add(DNSBL_CATEGORY_UNKNOWN)
         return categories

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
 
 setup(
     name='pydnsbl',
-    version='1.1.3',
+    version='1.1.5',
     description='Async dnsbl lists checker based on asyncio/aiodns.',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
 
 setup(
     name='pydnsbl',
-    version='1.1.2',
+    version='1.1.3',
     description='Async dnsbl lists checker based on asyncio/aiodns.',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Radically faster than using a local resolver in most cases.

Note: this should really be set per-provider, but looks like the minimal change is just to pass through to the resolver class.