### PR TITLE
Create new 'error' category

### DIFF
--- a/pydnsbl/providers.py
+++ b/pydnsbl/providers.py
@@ -74,10 +74,10 @@ _BASE_PROVIDERS = [
     'blackholes.five-ten-sg.com',
     'blacklist.woody.ch',
     'bogons.cymru.com',
-    # zen.spamhaus.org is already being used. abuseat.org redirects to spamhaus.org
+    # The provider zen.spamhaus.org is already being used. abuseat.org redirects to spamhaus.org
     # Additionally, abuseat.org has the same behaviour as zen.spamhaus.org
     # and we manage the new DNSBL_CATEGORY_ERROR in the zen.spamhaus.org Provider class
-    # 'cbl.abuseat.org', 
+    # 'cbl.abuseat.org',
     'combined.abuse.ch',
     'combined.rbl.msrbl.net',
     'db.wpbl.info',

--- a/pydnsbl/providers.py
+++ b/pydnsbl/providers.py
@@ -12,6 +12,7 @@ DNSBL_CATEGORY_MALWARE = 'malware'
 DNSBL_CATEGORY_CNC = 'cnc'
 DNSBL_CATEGORY_ABUSED = 'abused'
 DNSBL_CATEGORY_LEGIT = 'legit'
+DNSBL_CATEGORY_ERROR = 'error'
 
 class Provider(object):
 
@@ -57,6 +58,8 @@ class ZenSpamhaus(Provider):
                 categories.add(DNSBL_CATEGORY_SPAM)
             elif result.host in ['127.0.0.4', '127.0.0.5', '127.0.0.6', '127.0.0.7']:
                 categories.add(DNSBL_CATEGORY_EXPLOITS)
+            elif result.host in ['127.255.255.252', '127.255.255.254', '127.255.255.255']:
+                categories.add(DNSBL_CATEGORY_ERROR)
             else:
                 categories.add(DNSBL_CATEGORY_UNKNOWN)
         return categories
@@ -71,7 +74,10 @@ _BASE_PROVIDERS = [
     'blackholes.five-ten-sg.com',
     'blacklist.woody.ch',
     'bogons.cymru.com',
-    'cbl.abuseat.org',
+    # zen.spamhaus.org is already being used. abuseat.org redirects to spamhaus.org
+    # Additionally, abuseat.org has the same behaviour as zen.spamhaus.org
+    # and we manage the new DNSBL_CATEGORY_ERROR in the zen.spamhaus.org Provider class
+    # 'cbl.abuseat.org', 
     'combined.abuse.ch',
     'combined.rbl.msrbl.net',
     'db.wpbl.info',
@@ -122,7 +128,10 @@ class DblSpamhaus(Provider):
         '127.0.1.103': {DNSBL_CATEGORY_ABUSED, DNSBL_CATEGORY_SPAM},
         '127.0.1.104': {DNSBL_CATEGORY_ABUSED, DNSBL_CATEGORY_LEGIT, DNSBL_CATEGORY_PHISH},
         '127.0.1.105': {DNSBL_CATEGORY_ABUSED, DNSBL_CATEGORY_LEGIT, DNSBL_CATEGORY_MALWARE},
-        '127.0.1.106': {DNSBL_CATEGORY_ABUSED,  DNSBL_CATEGORY_LEGIT, DNSBL_CATEGORY_CNC}
+        '127.0.1.106': {DNSBL_CATEGORY_ABUSED,  DNSBL_CATEGORY_LEGIT, DNSBL_CATEGORY_CNC},
+        '127.255.255.252': {DNSBL_CATEGORY_ERROR},
+        '127.255.255.254': {DNSBL_CATEGORY_ERROR},
+        '127.255.255.255': {DNSBL_CATEGORY_ERROR},
     }
 
     def __init__(self, host='dbl.spamhaus.org'):


### PR DESCRIPTION
The 'error' classification returned by zen.spamhaus.org and cbl.abuseat.org should not be considered the IP as being 'listed' in the 'unknown' category. This leads to many false positives.

I created the 'error' category for the DSN responses '127.255.255.252', '127.255.255.254', and '127.255.255.255'  as described here: https://www.spamhaus.org/faqs/domain-blocklist/#291:~:text=The%20following%20special%20codes%20indicate%20an%20error%20condition

I modified the logic of process_results to prevent these entries form being added as "denylisted" entries. 

Also removed the provider 'cbl.abuseat.org' as it behaves as zen.spamhaus.org and it's redundant. This also prevents us from having to define a custom provider cloning the logic of ZenProvider class.