### PR TITLE
fix: removed ix.dnsbl.manitu.net

### DIFF
--- a/pydnsbl/providers.py
+++ b/pydnsbl/providers.py
@@ -82,7 +82,6 @@ _BASE_PROVIDERS = [
     'drone.abuse.ch',
     'images.rbl.msrbl.net',
     'ips.backscatterer.org',
-    'ix.dnsbl.manitu.net',
     'korea.services.net',
     'matrix.spfbl.net',
     'phishing.rbl.msrbl.net',


### PR DESCRIPTION
There decided to discontinue the project ix.dnsbl.manitu.net: https://www.heise.de/en/news/Spam-filter-DNS-blacklist-Nixspam-ceases-operation-10248714.html